### PR TITLE
fix: REFARQ — card dark mode, 12 artefatos do PDF, Google Forms e docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bibliomemojus — Site Oficial
 
-Site da **Rede Nacional de Bibliotecas Judiciárias**, construído com [Gatsby](https://www.gatsbyjs.com/) e hospedado no [Netlify](https://netlify.com). O conteúdo é gerenciado por meio de arquivos Markdown e um pipeline de automação via GitHub Actions que captura, revisa e publica notícias sem necessidade de acesso direto ao repositório.
+Site da **Rede Nacional de Bibliotecas Judiciárias**, construído com [Gatsby](https://www.gatsbyjs.com/) e hospedado no [Netlify](https://netlify.com). O conteúdo é gerenciado por meio de arquivos Markdown e JSON, com pipelines de automação via GitHub Actions para captura de notícias e curadoria de contratações públicas.
 
 ---
 
@@ -9,9 +9,9 @@ Site da **Rede Nacional de Bibliotecas Judiciárias**, construído com [Gatsby](
 | Camada | Tecnologia |
 |---|---|
 | Framework | Gatsby 5 (React) |
-| Conteúdo | Markdown + frontmatter YAML |
+| Conteúdo | Markdown + frontmatter YAML / JSON |
 | Deploy | Netlify (CD automático a cada push em `master`) |
-| Automação | GitHub Actions + Python |
+| Automação | GitHub Actions + Python + Node.js |
 
 ---
 
@@ -24,10 +24,15 @@ bibliomemojus/
 │   ├── eventos/         # ENABIJUDs e demais eventos (*.md)
 │   └── publicacoes/     # Publicações e materiais (*.md)
 ├── src/
-│   ├── pages/           # Páginas Gatsby (index, noticias, eventos, projetos…)
-│   └── components/      # Navbar, Footer, GTPage…
+│   ├── pages/           # Páginas Gatsby (index, noticias, refarq…)
+│   ├── components/      # Navbar, Footer, ArtefatoCard…
+│   └── data/
+│       └── artefatos/   # Artefatos de contratação em JSON (REFARQ)
+├── scripts/
+│   ├── capture-pncp.js          # Captura automática de contratações no PNCP
+│   └── refarq-form-handler.gs   # Apps Script para Google Forms → GitHub PR
 ├── .github/
-│   ├── workflows/       # GitHub Actions (captura, publicação)
+│   ├── workflows/       # GitHub Actions (captura, publicação, PNCP)
 │   ├── scripts/         # Scripts Python (captura.py, publica.py…)
 │   └── ISSUE_TEMPLATE/  # Formulários de issue para submissão de conteúdo
 └── static/              # Arquivos estáticos (favicon, imagens)
@@ -73,6 +78,107 @@ O mesmo fluxo existe para eventos (`candidato-evento`) e publicações (`candida
 | `publicado-evento` | Evento publicado |
 | `candidata-publicacao` | Publicação aguardando revisão |
 | `publicada-publicacao` | Publicação no site |
+| `refarq` | Artefato de contratação (REFARQ) |
+| `curadoria` | PR aguardando revisão do curador |
+| `comunidade` | Submetido via Google Forms |
+
+---
+
+## REFARQ — Banco de Contratações para Bibliotecas Judiciárias
+
+O módulo REFARQ (`/refarq`) reúne artefatos de contratação pública (editais, termos de referência, inexigibilidades etc.) relacionados a bibliotecas judiciárias em todo o Brasil. Os artefatos ficam em `src/data/artefatos/` como arquivos JSON individuais.
+
+### Fluxo de curadoria
+
+Artefatos entram com `"status": "pendente"` e só aparecem no site após serem aprovados (`"status": "aprovado"`). A aprovação acontece pelo merge do PR correspondente, após revisão do curador.
+
+```
+Submissão (formulário / captura automática)
+  → PR com status "pendente"
+  → Curador revisa, edita se necessário, faz merge
+  → Site publica com status "aprovado"
+```
+
+### Estrutura do arquivo JSON
+
+```json
+{
+  "id":              "orgao-categoria-ano",
+  "titulo":          "Título do processo",
+  "orgao":           "Nome do órgão contratante",
+  "esfera":          "federal | estadual | municipal",
+  "uf":              "SP",
+  "categoria":       "rfid | digitalizacao | aquisicaoLivros | ...",
+  "tipoArtefato":    "edital | termo-de-referencia | inexigibilidade | ...",
+  "dataPublicacao":  "2024-03-15",
+  "dataCaptura":     "2026-05-17",
+  "url":             "https://pncp.gov.br/app/editais/...",
+  "urlFonte":        "https://pncp.gov.br",
+  "resumo":          "Descrição do objeto contratado.",
+  "valor":           150000,
+  "status":          "aprovado | pendente",
+  "tags":            ["RFID", "biblioteca judiciária"],
+  "contribuidor":    "Nome / Instituição (opcional)"
+}
+```
+
+### Categorias disponíveis
+
+| Chave | Label |
+|---|---|
+| `memoriaInstitucional` | Memória Institucional |
+| `aquisicaoLivros` | Aquisição de Livros |
+| `digitalizacao` | Digitalização |
+| `higienizacao` | Higienização / Conservação |
+| `bibliotecaDigital` | Biblioteca Digital |
+| `terceirizacao` | Terceirização |
+| `estagiarios` | Estágio |
+| `sistemasGestao` | Sistemas de Gestão (SIGB) |
+| `inventarioAcervo` | Inventário de Acervo |
+| `rfid` | RFID |
+| `restauracao` | Restauração |
+| `consultoria` | Consultoria |
+| `apresentacoesCulturais` | Apresentações Culturais |
+
+### Captura automática (PNCP)
+
+O workflow `capture-pncp.yml` roda diariamente às 06h UTC e consulta a API do PNCP. Novos artefatos em escopo abrem PRs automaticamente com labels `refarq, curadoria`.
+
+### Submissão via Google Forms (comunidade)
+
+Qualquer membro da rede pode submeter artefatos via formulário sem acesso ao GitHub. O script `scripts/refarq-form-handler.gs` processa cada resposta e abre um PR automaticamente.
+
+**Para configurar:**
+
+1. Crie o Google Form com os campos abaixo (nomes exatos):
+
+   | Campo | Tipo |
+   |---|---|
+   | Título do artefato | Resposta curta |
+   | Órgão contratante | Resposta curta |
+   | Esfera | Múltipla escolha: `Federal` / `Estadual` / `Municipal` |
+   | UF | Lista suspensa |
+   | Categoria | Múltipla escolha (ver tabela acima) |
+   | Tipo de artefato | Múltipla escolha |
+   | Data de publicação | Data |
+   | URL no PNCP | Resposta curta |
+   | Resumo | Parágrafo |
+   | Valor estimado (R$) | Resposta curta *(opcional)* |
+   | Seu nome / instituição | Resposta curta *(opcional)* |
+
+2. Vincule o Form a uma Planilha: **Respostas → ícone de planilha → Criar planilha**
+
+3. Na planilha: **Extensões → Apps Script** → cole o conteúdo de `scripts/refarq-form-handler.gs`
+
+4. Em **Configurações do projeto → Propriedades do script**, adicione:
+   - Chave: `GITHUB_TOKEN`
+   - Valor: [fine-grained token](https://github.com/settings/tokens?type=beta) com permissões **Contents** e **Pull requests** (leitura + escrita) apenas neste repositório
+
+5. Crie o gatilho: **Gatilhos → + Adicionar → `onFormSubmit` → Ao enviar formulário**
+
+6. Crie as labels `refarq`, `curadoria` e `comunidade` no repositório GitHub
+
+A cada envio, o script cria um branch, grava o JSON com `status: "pendente"` e abre um PR para curadoria.
 
 ---
 

--- a/scripts/refarq-form-handler.gs
+++ b/scripts/refarq-form-handler.gs
@@ -1,0 +1,235 @@
+// ================================================================
+// REFARQ – Processador de submissões via Google Forms
+//
+// Como usar:
+//   1. Crie o Google Form com os campos descritos abaixo
+//   2. Vincule o Form a uma Planilha Google (Respostas → Planilha)
+//   3. Na Planilha: Extensões → Apps Script → cole este código
+//   4. Em "Configurações do projeto" → "Propriedades do script",
+//      adicione: GITHUB_TOKEN = <seu fine-grained token>
+//   5. Adicione o gatilho: Gatilhos → + Adicionar gatilho
+//      Função: onFormSubmit | Evento: "Ao enviar formulário"
+//
+// Campos obrigatórios no Google Form (nomes EXATOS):
+//   • Título do artefato        (Resposta curta)
+//   • Órgão contratante         (Resposta curta)
+//   • Esfera                    (Múltipla escolha: Federal / Estadual / Municipal)
+//   • UF                        (Lista suspensa com todas as siglas)
+//   • Categoria                 (Múltipla escolha — ver CATEGORIA_MAP abaixo)
+//   • Tipo de artefato          (Múltipla escolha — ver TIPO_MAP abaixo)
+//   • Data de publicação        (Data)
+//   • URL no PNCP               (Resposta curta)
+//   • Resumo                    (Parágrafo)
+//
+// Campos opcionais:
+//   • Valor estimado (R$)       (Resposta curta — só números, ex: 85000)
+//   • Seu nome / instituição    (Resposta curta — para crédito no PR)
+//
+// GitHub fine-grained token necessário:
+//   Permissões: Contents (read & write) + Pull requests (read & write)
+//   Repositório: carlosferian/bibliomemojus
+// ================================================================
+
+const GITHUB_OWNER = 'carlosferian'
+const GITHUB_REPO  = 'bibliomemojus'
+const BASE_BRANCH  = 'master'
+const PR_LABELS    = ['refarq', 'curadoria', 'comunidade']
+
+const CATEGORIA_MAP = {
+  'Memória Institucional':      'memoriaInstitucional',
+  'Aquisição de Livros':        'aquisicaoLivros',
+  'Digitalização':              'digitalizacao',
+  'Higienização / Conservação': 'higienizacao',
+  'Biblioteca Digital':         'bibliotecaDigital',
+  'Terceirização':              'terceirizacao',
+  'Estágio':                    'estagiarios',
+  'Sistemas de Gestão (SIGB)':  'sistemasGestao',
+  'Inventário de Acervo':       'inventarioAcervo',
+  'RFID':                       'rfid',
+  'Restauração':                'restauracao',
+  'Consultoria':                'consultoria',
+  'Apresentações Culturais':    'apresentacoesCulturais',
+  'Outro':                      'outro',
+}
+
+const TIPO_MAP = {
+  'Edital':                    'edital',
+  'Termo de Referência':       'termo-de-referencia',
+  'Estudo Técnico Preliminar': 'estudo-tecnico-preliminar',
+  'Ata de Registro de Preços': 'ata-de-registro-de-precos',
+  'Contrato':                  'contrato',
+  'Dispensa':                  'dispensa',
+  'Inexigibilidade':           'inexigibilidade',
+  'Projeto Básico':            'projeto-basico',
+  'Outro':                     'outro',
+}
+
+// ── Entrada principal ─────────────────────────────────────────
+function onFormSubmit(e) {
+  const token = PropertiesService.getScriptProperties().getProperty('GITHUB_TOKEN')
+  if (!token) throw new Error('GITHUB_TOKEN não configurado nas propriedades do script.')
+
+  const r = e.namedValues
+
+  const titulo    = getField(r, 'Título do artefato')
+  const orgao     = getField(r, 'Órgão contratante')
+  const esfera    = getField(r, 'Esfera').toLowerCase()
+  const uf        = getField(r, 'UF').toUpperCase()
+  const catLabel  = getField(r, 'Categoria')
+  const tipoLabel = getField(r, 'Tipo de artefato')
+  const dataPub   = parseDate(getField(r, 'Data de publicação'))
+  const url       = getField(r, 'URL no PNCP')
+  const resumo    = getField(r, 'Resumo')
+  const valorRaw  = getField(r, 'Valor estimado (R$)')
+  const contrib   = getField(r, 'Seu nome / instituição')
+
+  const categoria    = CATEGORIA_MAP[catLabel]  || 'outro'
+  const tipoArtefato = TIPO_MAP[tipoLabel]       || 'outro'
+  const hoje         = new Date().toISOString().split('T')[0]
+  const ano          = dataPub ? dataPub.slice(0, 4) : hoje.slice(0, 4)
+  const valor        = valorRaw
+    ? parseFloat(valorRaw.replace(/\./g, '').replace(',', '.')) || null
+    : null
+
+  const id       = `${slugify(orgao).slice(0, 24)}-${categoria}-${ano}-${Date.now().toString(36)}`
+  const filename = `${id}.json`
+  const filePath = `src/data/artefatos/${filename}`
+
+  const artefato = {
+    id,
+    titulo,
+    orgao,
+    esfera,
+    uf,
+    categoria,
+    tipoArtefato,
+    dataPublicacao: dataPub || hoje,
+    dataCaptura:    hoje,
+    url:            url || 'https://pncp.gov.br',
+    urlFonte:       'https://pncp.gov.br',
+    resumo,
+    valor,
+    status:         'pendente',
+    tags:           [],
+    contribuidor:   contrib || null,
+  }
+
+  const b64 = Utilities.base64Encode(
+    JSON.stringify(artefato, null, 2),
+    Utilities.Charset.UTF_8
+  )
+  const branchName = `refarq/contrib-${id}`
+
+  // 1. SHA do branch base
+  const baseSha = getRefSha(token, `heads/${BASE_BRANCH}`)
+
+  // 2. Cria branch para a contribuição
+  createRef(token, `refs/heads/${branchName}`, baseSha)
+
+  // 3. Cria o arquivo JSON no branch
+  putFile(token, filePath, b64, `feat(refarq): contribuição via formulário — ${titulo}`, branchName)
+
+  // 4. Abre PR para curadoria
+  const pr = openPR(token, `[REFARQ] ${titulo}`, buildPrBody(artefato, contrib), branchName, BASE_BRANCH)
+
+  // 5. Adiciona labels ao PR
+  if (pr && pr.number) {
+    addLabels(token, pr.number, PR_LABELS)
+  }
+
+  Logger.log(`PR criado: ${pr.html_url}`)
+}
+
+// ── API GitHub ────────────────────────────────────────────────
+function ghRequest(token, method, path, body) {
+  const opts = {
+    method,
+    headers: {
+      Authorization:        `Bearer ${token}`,
+      Accept:               'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type':       'application/json',
+    },
+    muteHttpExceptions: true,
+  }
+  if (body) opts.payload = JSON.stringify(body)
+
+  const res  = UrlFetchApp.fetch(
+    `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/${path}`,
+    opts
+  )
+  const code = res.getResponseCode()
+  if (code >= 400) {
+    throw new Error(`GitHub ${method} ${path} → HTTP ${code}: ${res.getContentText()}`)
+  }
+  return JSON.parse(res.getContentText())
+}
+
+function getRefSha(token, ref) {
+  return ghRequest(token, 'GET', `git/ref/${ref}`).object.sha
+}
+
+function createRef(token, ref, sha) {
+  ghRequest(token, 'POST', 'git/refs', { ref, sha })
+}
+
+function putFile(token, path, content, message, branch) {
+  ghRequest(token, 'PUT', `contents/${path}`, { message, content, branch })
+}
+
+function openPR(token, title, body, head, base) {
+  return ghRequest(token, 'POST', 'pulls', { title, body, head, base })
+}
+
+function addLabels(token, prNumber, labels) {
+  ghRequest(token, 'POST', `issues/${prNumber}/labels`, { labels })
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+function getField(namedValues, key) {
+  const v = namedValues[key]
+  return (v && v[0]) ? v[0].trim() : ''
+}
+
+function parseDate(str) {
+  if (!str) return null
+  if (/^\d{4}-\d{2}-\d{2}$/.test(str)) return str
+  const m = str.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+  if (m) return `${m[3]}-${m[2].padStart(2, '0')}-${m[1].padStart(2, '0')}`
+  return null
+}
+
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+function buildPrBody(a, contrib) {
+  const valorStr = a.valor
+    ? `R$ ${a.valor.toLocaleString('pt-BR')}`
+    : '—'
+
+  return `## Artefato submetido via formulário da comunidade
+
+| Campo | Valor |
+|---|---|
+| **Órgão** | ${a.orgao} |
+| **Esfera** | ${a.esfera} |
+| **UF** | ${a.uf} |
+| **Categoria** | ${a.categoria} |
+| **Tipo** | ${a.tipoArtefato} |
+| **Data publicação** | ${a.dataPublicacao} |
+| **URL** | ${a.url} |
+| **Valor** | ${valorStr} |
+| **Contribuidor** | ${contrib || '—'} |
+
+### Resumo
+${a.resumo}
+
+---
+> Submissão automática via Google Forms.
+> Status \`pendente\` — visível no site somente após o curador alterar para \`aprovado\` e fazer merge.`
+}

--- a/src/components/refarq/ArtefatoCard.jsx
+++ b/src/components/refarq/ArtefatoCard.jsx
@@ -76,35 +76,25 @@ const ArtefatoCard = ({ artefato, index = 0 }) => {
         <p className="artefato-card-resumo">{resumo}</p>
       )}
 
-      <footer className="artefato-card-footer">
-        <div className="artefato-card-meta">
-          <span className="artefato-badge artefato-badge--cat">
-            {CATEGORIA_LABELS[categoria] || categoria}
-          </span>
-          {valor && (
-            <span className="artefato-card-valor">{formatValor(valor)}</span>
-          )}
-        </div>
-
-        {url && (
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="artefato-card-link"
-            aria-label={`Ver artefato: ${titulo}`}
-          >
-            Ver no PNCP →
-          </a>
+      <div className="artefato-card-meta">
+        <span className="artefato-badge artefato-badge--cat">
+          {CATEGORIA_LABELS[categoria] || categoria}
+        </span>
+        {valor && (
+          <span className="artefato-card-valor">{formatValor(valor)}</span>
         )}
-      </footer>
+      </div>
 
-      {tags.length > 0 && (
-        <ul className="artefato-card-tags" aria-label="Tags">
-          {tags.map(tag => (
-            <li key={tag} className="artefato-tag">{tag}</li>
-          ))}
-        </ul>
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="artefato-card-link"
+          aria-label={`Ver artefato: ${titulo}`}
+        >
+          Ver no PNCP →
+        </a>
       )}
     </article>
   )

--- a/src/data/artefatos/jf-rfid-controle-pe90001-2024.json
+++ b/src/data/artefatos/jf-rfid-controle-pe90001-2024.json
@@ -1,0 +1,17 @@
+{
+  "id": "jf-rfid-controle-pe90001-2024",
+  "titulo": "Sistema RFID para controle de acesso e gestão de acervo na Justiça Federal",
+  "orgao": "Conselho da Justiça Federal",
+  "esfera": "federal",
+  "uf": "DF",
+  "categoria": "rfid",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2024-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/00508903000188-1-000081/2024",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para aquisição e implantação de sistema RFID para controle de acesso ao acervo bibliográfico e gestão automatizada de empréstimo e devolução de obras na biblioteca da Justiça Federal.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["RFID", "controle de acesso", "acervo", "Justiça Federal", "biblioteca judiciária", "automação"]
+}

--- a/src/data/artefatos/ma-guarda-externa-ged-2023.json
+++ b/src/data/artefatos/ma-guarda-externa-ged-2023.json
@@ -1,0 +1,17 @@
+{
+  "id": "ma-guarda-externa-ged-2023",
+  "titulo": "Guarda externa de documentos e sistema GED — Estado do Maranhão",
+  "orgao": "Estado do Maranhão",
+  "esfera": "estadual",
+  "uf": "MA",
+  "categoria": "sistemasGestao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2023-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/06354468000160-1-000239/2023",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para contratação integrada de serviços de guarda externa de documentos físicos e implantação de sistema de Gerenciamento Eletrônico de Documentos (GED) para órgãos do Estado do Maranhão, incluindo digitalização, indexação e disponibilização de acervo.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["guarda externa", "GED", "gestão documental", "Maranhão", "digitalização", "acervo público"]
+}

--- a/src/data/artefatos/mppa-ged-pe90023-2024.json
+++ b/src/data/artefatos/mppa-ged-pe90023-2024.json
@@ -1,0 +1,17 @@
+{
+  "id": "mppa-ged-pe90023-2024",
+  "titulo": "Gestão documental e sistema GED para o Ministério Público do Estado do Pará",
+  "orgao": "Ministério Público do Estado do Pará",
+  "esfera": "estadual",
+  "uf": "PA",
+  "categoria": "sistemasGestao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2024-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/05054960000158-1-000059/2024",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para contratação de serviços de gestão documental integrada com solução de Gerenciamento Eletrônico de Documentos (GED), abrangendo digitalização, classificação, indexação e disponibilização de acervo documental do MPPA.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["GED", "gestão documental", "digitalização", "Ministério Público", "Pará", "sistema eletrônico"]
+}

--- a/src/data/artefatos/parauna-restauracao-biblioteca-2024.json
+++ b/src/data/artefatos/parauna-restauracao-biblioteca-2024.json
@@ -1,0 +1,17 @@
+{
+  "id": "parauna-restauracao-biblioteca-2024",
+  "titulo": "Restauração da Biblioteca Pública Municipal Professora Margarida — Paraúna/GO",
+  "orgao": "Fundo Municipal de Educação de Paraúna",
+  "esfera": "municipal",
+  "uf": "GO",
+  "categoria": "restauracao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2024-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/45965982000194-1-000033/2024",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Licitação para execução de obras de restauração, reforma e adequação do espaço físico da Biblioteca Pública Municipal Professora Margarida, localizada em Paraúna/GO, visando a melhoria das condições de atendimento e preservação do acervo.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["restauração", "biblioteca pública", "reforma", "Goiás", "infraestrutura", "acervo municipal"]
+}

--- a/src/data/artefatos/stf-rfid-biblioteca-2023.json
+++ b/src/data/artefatos/stf-rfid-biblioteca-2023.json
@@ -1,0 +1,17 @@
+{
+  "id": "stf-rfid-biblioteca-2023",
+  "titulo": "Manutenção preventiva e corretiva dos sistemas RFID da Biblioteca Ministro Victor Nunes Leal",
+  "orgao": "Supremo Tribunal Federal",
+  "esfera": "federal",
+  "uf": "DF",
+  "categoria": "rfid",
+  "tipoArtefato": "inexigibilidade",
+  "dataPublicacao": "2023-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/00531640000128-1-000216/2023",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Prestação de serviços especializados em manutenção preventiva e corretiva dos sistemas e equipamentos eletrônicos com tecnologia RFID, marca Bibliotheca + 3M, instalados e em operação na Biblioteca Ministro Victor Nunes Leal, com opção de fornecimento de peças.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["RFID", "biblioteca judiciária", "STF", "Bibliotheca 3M", "manutenção"]
+}

--- a/src/data/artefatos/tcu-rfid-coletores-pe90015-2025.json
+++ b/src/data/artefatos/tcu-rfid-coletores-pe90015-2025.json
@@ -1,0 +1,17 @@
+{
+  "id": "tcu-rfid-coletores-pe90015-2025",
+  "titulo": "Aquisição de coletores RFID para gestão do acervo bibliográfico do TCU",
+  "orgao": "Tribunal de Contas da União",
+  "esfera": "federal",
+  "uf": "DF",
+  "categoria": "rfid",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2025-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/00414607000118-1-000086/2025",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para aquisição de coletores de dados RFID portáteis destinados ao inventário e controle do acervo da biblioteca do Tribunal de Contas da União, com software de gestão e suporte técnico.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["RFID", "coletores", "inventário", "TCU", "biblioteca judiciária", "controle de acervo"]
+}

--- a/src/data/artefatos/tjmg-restauracao-predial-2024.json
+++ b/src/data/artefatos/tjmg-restauracao-predial-2024.json
@@ -1,0 +1,17 @@
+{
+  "id": "tjmg-restauracao-predial-2024",
+  "titulo": "Projetos de restauração predial de unidades do Tribunal de Justiça de Minas Gerais",
+  "orgao": "Tribunal de Justiça do Estado de Minas Gerais",
+  "esfera": "estadual",
+  "uf": "MG",
+  "categoria": "restauracao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2024-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/21154554000113-1-000725/2024",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Contratação de empresa especializada para elaboração de projetos técnicos de restauração predial de unidades do TJMG, incluindo bibliotecas e arquivos do Poder Judiciário estadual, com levantamento de necessidades e especificação de intervenções.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["restauração predial", "projeto técnico", "TJMG", "Poder Judiciário", "infraestrutura", "biblioteca judiciária"]
+}

--- a/src/data/artefatos/tjrn-higienizacao-pe90034-2024.json
+++ b/src/data/artefatos/tjrn-higienizacao-pe90034-2024.json
@@ -1,0 +1,17 @@
+{
+  "id": "tjrn-higienizacao-pe90034-2024",
+  "titulo": "Higienização e conservação de bens do acervo do Poder Judiciário do RN",
+  "orgao": "Tribunal de Justiça do Estado do Rio Grande do Norte",
+  "esfera": "estadual",
+  "uf": "RN",
+  "categoria": "higienizacao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2024-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/08546459000105-1-000043/2024",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para contratação de serviços de higienização, conservação e acondicionamento de bens documentais e bibliográficos pertencentes ao acervo do Poder Judiciário do Estado do Rio Grande do Norte.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["higienização", "conservação", "acervo", "TJRN", "Poder Judiciário", "documentos"]
+}

--- a/src/data/artefatos/tjsp-armazenamento-inexigibilidade-2025.json
+++ b/src/data/artefatos/tjsp-armazenamento-inexigibilidade-2025.json
@@ -1,0 +1,17 @@
+{
+  "id": "tjsp-armazenamento-inexigibilidade-2025",
+  "titulo": "Armazenamento externo de documentos e acervo do Tribunal de Justiça de São Paulo",
+  "orgao": "Tribunal de Justiça do Estado de São Paulo",
+  "esfera": "estadual",
+  "uf": "SP",
+  "categoria": "sistemasGestao",
+  "tipoArtefato": "inexigibilidade",
+  "dataPublicacao": "2025-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/46634531000137-1-000064/2025",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Inexigibilidade de licitação para contratação de serviços de guarda e armazenamento externo de documentos físicos do acervo do TJSP, incluindo gerenciamento, transporte, acesso e destruição segura de documentos.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["armazenamento", "guarda externa", "documentos", "TJSP", "acervo judiciário", "gestão documental"]
+}

--- a/src/data/artefatos/tse-digitalizacao-pe55-2023.json
+++ b/src/data/artefatos/tse-digitalizacao-pe55-2023.json
@@ -1,0 +1,17 @@
+{
+  "id": "tse-digitalizacao-pe55-2023",
+  "titulo": "Digitalização de documentos do Tribunal Superior Eleitoral",
+  "orgao": "Tribunal Superior Eleitoral",
+  "esfera": "federal",
+  "uf": "DF",
+  "categoria": "digitalizacao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2023-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/00509018000113-1-001915/2023",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para contratação de empresa especializada em digitalização de documentos institucionais, com indexação e armazenamento eletrônico, visando a preservação e acesso ao acervo documental do TSE.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["digitalização", "acervo", "TSE", "documentos", "judiciário federal"]
+}

--- a/src/data/artefatos/tse-scanner-pe90059-2024.json
+++ b/src/data/artefatos/tse-scanner-pe90059-2024.json
@@ -1,0 +1,17 @@
+{
+  "id": "tse-scanner-pe90059-2024",
+  "titulo": "Aquisição de scanners de alta produção para digitalização do acervo documental",
+  "orgao": "Tribunal Superior Eleitoral",
+  "esfera": "federal",
+  "uf": "DF",
+  "categoria": "digitalizacao",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2024-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/00509018000113-1-004068/2024",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Pregão eletrônico para aquisição de equipamentos scanners de alta produção destinados à digitalização do acervo documental e bibliográfico do Tribunal Superior Eleitoral, com suporte técnico incluso.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["scanner", "digitalização", "equipamento", "TSE", "judiciário federal", "alta produção"]
+}

--- a/src/data/artefatos/ufmg-treinamento-archivematica-2023.json
+++ b/src/data/artefatos/ufmg-treinamento-archivematica-2023.json
@@ -1,0 +1,17 @@
+{
+  "id": "ufmg-treinamento-archivematica-2023",
+  "titulo": "Treinamento em Archivematica e AtoM para gestão de arquivos digitais — UFMG",
+  "orgao": "Universidade Federal de Minas Gerais",
+  "esfera": "federal",
+  "uf": "MG",
+  "categoria": "consultoria",
+  "tipoArtefato": "edital",
+  "dataPublicacao": "2023-01-01",
+  "dataCaptura": "2026-05-17",
+  "url": "https://pncp.gov.br/app/editais/17217985000104-1-000073/2023",
+  "urlFonte": "https://pncp.gov.br",
+  "resumo": "Contratação de capacitação técnica em plataformas de preservação digital Archivematica e AtoM (Access to Memory), destinada a profissionais de bibliotecas e arquivos da UFMG, abrangendo fluxos de ingestão, preservação e acesso a objetos digitais.",
+  "valor": null,
+  "status": "aprovado",
+  "tags": ["Archivematica", "AtoM", "preservação digital", "capacitação", "UFMG", "arquivo digital", "gestão de acervo"]
+}

--- a/src/style.css
+++ b/src/style.css
@@ -446,16 +446,13 @@ footer { background: #0D1720; color: rgba(255,255,255,.55); padding: 60px 28px 3
 .artefato-card-titulo { font-size: 14px; font-weight: 600; color: #16222F; line-height: 1.4; }
 .artefato-card-orgao { font-size: 12px; color: #6b6760; }
 .artefato-card-resumo { font-size: 13px; color: #1a1916; line-height: 1.55; flex: 1; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
-.artefato-card-footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: auto; padding-top: 10px; border-top: 1px solid #e2ded6; }
-.artefato-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.artefato-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: auto; }
 .artefato-card-valor { font-size: 12px; font-weight: 600; color: #16222F; }
 .artefato-card-link {
   font-size: 12px; font-weight: 600; color: #9a7c3a; text-decoration: none;
   white-space: nowrap; transition: color .15s;
 }
 .artefato-card-link:hover { color: #16222F; }
-.artefato-card-tags { list-style: none; display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
-.artefato-tag { font-size: 10px; background-color: #f4f2ed; color: #6b6760; padding: 2px 8px; border-radius: 100px; border: 1px solid #e2ded6; }
 
 /* Vazio */
 .refarq-empty { text-align: center; padding: 64px 24px; color: var(--muted); }

--- a/src/style.css
+++ b/src/style.css
@@ -424,6 +424,7 @@ footer { background: #0D1720; color: rgba(255,255,255,.55); padding: 60px 28px 3
   background-color: #ffffff; border: 1px solid #e2ded6; border-radius: 14px;
   padding: 22px; display: flex; flex-direction: column; gap: 10px;
   transition: box-shadow .2s, transform .2s; color: #1a1916;
+  color-scheme: light;
 }
 .artefato-card:hover { box-shadow: 0 8px 32px rgba(22,34,47,.12); transform: translateY(-2px); }
 
@@ -446,11 +447,12 @@ footer { background: #0D1720; color: rgba(255,255,255,.55); padding: 60px 28px 3
 .artefato-card-titulo { font-size: 14px; font-weight: 600; color: #16222F; line-height: 1.4; }
 .artefato-card-orgao { font-size: 12px; color: #6b6760; }
 .artefato-card-resumo { font-size: 13px; color: #1a1916; line-height: 1.55; flex: 1; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
-.artefato-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: auto; }
+.artefato-card-header { background-color: #ffffff; }
+.artefato-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: auto; background-color: #ffffff; }
 .artefato-card-valor { font-size: 12px; font-weight: 600; color: #16222F; }
 .artefato-card-link {
   font-size: 12px; font-weight: 600; color: #9a7c3a; text-decoration: none;
-  white-space: nowrap; transition: color .15s;
+  white-space: nowrap; transition: color .15s; background-color: #ffffff;
 }
 .artefato-card-link:hover { color: #16222F; }
 


### PR DESCRIPTION
## O que este PR entrega

### Correções visuais (REFARQ)
- Remove o quadro interno (footer com `border-top`) do card de artefatos
- Adiciona `color-scheme: light` diretamente no `.artefato-card` e `background-color: #ffffff` nos containers internos — elimina o fundo preto que aparecia no Android com dark mode ativado
- Remove tags dos cards (layout mais limpo)
- Corrige texto invisível no hero da página
- Corrige links 404 nos artefatos de exemplo

### Banco de Contratações — novos artefatos
12 artefatos inseridos manualmente a partir da análise do PDF do Repositório de Contratações:
- STF — RFID Biblioteca Ministro Victor Nunes Leal
- TSE — Digitalização de documentos (PE 55/2023)
- TSE — Scanners de alta produção (PE 90059/2024)
- MPPA — GED + gestão documental (PE 90023/2024)
- Conselho JF — RFID controle de acesso (PE 90001/2024)
- TCU — Coletores RFID (PE 90015/2025)
- TJRN — Higienização documental (PE 90034/2024)
- TJSP — Armazenamento externo (Inexigibilidade 2025)
- Paraúna/GO — Restauração Biblioteca Professora Margarida
- TJMG — Projetos de restauração predial
- UFMG — Treinamento Archivematica/AtoM
- Estado do MA — Guarda externa + GED

### Integração Google Forms
- Script `scripts/refarq-form-handler.gs` (Apps Script completo)
- Cada submissão cria automaticamente um branch, grava o JSON com `status: pendente` e abre PR para curadoria

### Documentação
- README atualizado com seção completa do REFARQ: estrutura JSON, categorias, fluxo de curadoria, captura automática PNCP e passo a passo do Google Forms

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvCGFQj13eqnNKoB7v9HDw)_